### PR TITLE
feat: add support for GraphQL from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We are decoupled from any HTTP messaging client with help by [HTTPlug](https://h
 require_once __DIR__ . '/vendor/autoload.php';
 
 $client = new \Worksome\Sdk\Client();
-$repositories = $client->graph()->query(<<<GQL
+$repositories = $client->graph()->execute(<<<GQL
     query {
         profile {
             name

--- a/src/Api/GraphQL.php
+++ b/src/Api/GraphQL.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Worksome\Sdk\Api;
 
+use Worksome\Sdk\Exception\InvalidArgumentException;
+
 class GraphQL extends AbstractApi
 {
     /**
@@ -11,11 +13,25 @@ class GraphQL extends AbstractApi
      *
      * @return array<int|string, mixed>|string
      */
-    public function query(string $query, array $variables = []): array|string
+    public function execute(string $query, array $variables = []): array|string
     {
         return $this->post('/graphql', [
             'query' => $query,
             'variables' => $variables
         ]);
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     *
+     * @return array<int|string, mixed>|string
+     */
+    public function fromFile(string $file, array $variables = []): array|string
+    {
+        if (! file_exists($file) || ! is_readable($file)) {
+            throw new InvalidArgumentException('The provided file does not exist or is unreadable.');
+        }
+
+        return $this->execute((string) file_get_contents($file), $variables);
     }
 }

--- a/tests/Api/GraphQlTest.php
+++ b/tests/Api/GraphQlTest.php
@@ -28,10 +28,13 @@ GQL;
     $api = $this->getApiMock();
 
     $api->expects($this->once())
-        ->method('query')
-        ->with($query)
+        ->method('post')
+        ->with('/graphql', [
+            'query' => $query,
+            'variables' => [],
+        ])
         ->willReturn($response);
 
     /** @var GraphQL $api */
-    expect($api->query($query))->toBe($response);
+    expect($api->execute($query))->toBe($response);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,7 +24,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $client = Client::createWithHttpClient($httpClient);
 
         return $this->getMockBuilder($this->apiClass)
-            ->onlyMethods(['get', 'post', 'postRaw', 'patch', 'delete', 'put', 'head', 'query'])
+            ->onlyMethods(['get', 'post', 'postRaw', 'patch', 'delete', 'put', 'head'])
             ->setConstructorArgs([$client])
             ->getMock();
     }


### PR DESCRIPTION
This also renames `query()` to `execute()` which I think fits the usage more accurately.