### PR TITLE
feat: JIRA-14842 Add a `baseUri` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ $client = new \Worksome\Sdk\Client();
 $client->authenticate($apiToken);
 ```
 
+#### Using a different base URI
+
+The Worksome SDK defaults to using the `https://api.worksome.com` URI, however if a custom URI is required, this can be passed to the constructor:
+
+```php
+$client = new \Worksome\Sdk\Client(baseUri: 'https://api.local');
+```
+
 #### Using a different HTTP client
 
 Thanks to [HTTPlug](https://httplug.io), we support the use of many HTTP clients. For example, to use the Symfony HTTP

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,15 +26,19 @@ use Worksome\Sdk\HttpClient\Plugin\Authentication;
  */
 final class Client
 {
+    public const string BASE_URI = 'https://api.worksome.com';
+
     private Builder $httpClientBuilder;
 
-    public function __construct(Builder|null $httpClientBuilder = null)
+    public function __construct(Builder|null $httpClientBuilder = null, string $baseUri = self::BASE_URI)
     {
         $this->httpClientBuilder = $builder = $httpClientBuilder ?? new Builder();
 
         $builder->addPlugin(new RedirectPlugin());
         $builder->addPlugin(
-            new AddHostPlugin(Psr17FactoryDiscovery::findUriFactory()->createUri('https://api.worksome.com'))
+            new AddHostPlugin(
+                Psr17FactoryDiscovery::findUriFactory()->createUri($baseUri)
+            )
         );
         $builder->addPlugin(new HeaderDefaultsPlugin([
             'User-Agent' => 'worksome-sdk (https://github.com/worksome/sdk-php)',


### PR DESCRIPTION
This adds a new `baseUri` parameter to the constructor to allow easy change of domain.